### PR TITLE
Build Context der Cuzoo Container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.7"
 services:
   cuzoo-frontend:
     image: cuzoo/frontend:latest
+    build: "frontend"
     container_name: cuzoo-frontend
     links:
       - cuzoo-backend
@@ -11,6 +12,7 @@ services:
 
   cuzoo-backend:
     image: cuzoo/backend:latest
+    build: "backend"
     container_name: cuzoo-backend
     depends_on:
       - "postgre-db"


### PR DESCRIPTION
Dieser PR fügt im `docker-compose.yml` File den Pfad zu den Cuzoo Containern hinzu. Im Teamcity wurden bisher immer erst die Images gebaut und anschließend das docker-compose.yml ausgeführt. Wenn der erste Schritt, z. B. auf einer lokalen Maschine nach dem Klonen des Repositories, nicht ausgeführt wird, versucht Docker die Cuzoo Images aus dem öffentlichen Docker Hub zu laden und wirft einen Fehler. 